### PR TITLE
feat: add connection charSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ use PHPMailer\PHPMailer\PHPMailer;
 Mailer::connect([
   'host' => 'smtp.mailtrap.io',
   'port' => 2525,
-  'charSet' => 'utf-8',
+  'charSet' => PHPMailer::CHARSET_UTF8,
   'security' => PHPMailer::ENCRYPTION_STARTTLS,
   'auth' => [
     'username' => 'MAILTRAP_USERNAME',

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ use PHPMailer\PHPMailer\PHPMailer;
 Mailer::connect([
   'host' => 'smtp.mailtrap.io',
   'port' => 2525,
+  'charSet' => 'utf-8',
   'security' => PHPMailer::ENCRYPTION_STARTTLS,
   'auth' => [
     'username' => 'MAILTRAP_USERNAME',

--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -46,6 +46,10 @@ class Mailer
         static::$mailer->Host = $connection['host'];
         static::$mailer->Port = $connection['port'];
 
+        if (isset($connection['charSet'])) {
+            static::$mailer->CharSet = $connection['charSet'];
+        }
+
         if (isset($connection['keepAlive']) || isset(static::$config['keepAlive'])) {
             static::$mailer->SMTPKeepAlive = $connection['keepAlive'] ?? static::$config['keepAlive'];
         }


### PR DESCRIPTION
<!--
	Please only send a pull request to branches which are currently supported: https://leafphp.dev/community/contributing.html#pull-request-guidelines

	Pull requests without a descriptive title, thorough description, or tests will be closed.
-->

## Description

`PHPMailer` supports `utf-8`, `us-ascii` and `iso-8859-1` char sets with this pull request the ability to change between them is granted.

## Related Issue

<!-- If suggesting a new feature or change, please discuss it in an issue first -->
<!-- If fixing a bug, there should be an issue describing it with steps to reproduce -->