### PR TITLE
fix: safely access debug config with null coalescing

### DIFF
--- a/src/Mail/Mailer.php
+++ b/src/Mail/Mailer.php
@@ -124,10 +124,12 @@ class Mailer
      */
     public static function send(Mail $mail)
     {
-        if (static::$config['debug'] === "SERVER") {
+        $debug = static::$config['debug'] ?? SMTP::DEBUG_OFF;
+
+        if ($debug === "SERVER") {
             static::$mailer->SMTPDebug = SMTP::DEBUG_SERVER;
         } else {
-            static::$mailer->SMTPDebug = static::$config['debug'] ?? SMTP::DEBUG_OFF;
+            static::$mailer->SMTPDebug = $debug;
         }
 
         if (static::validate($mail)) {


### PR DESCRIPTION
## What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe below

## Description

Fix undefined array key "debug" error in Mailer::send()

### Current Behavior
When sending an email without first setting the debug configuration, the Mailer throws an "Undefined array key debug" error because it tries to access `static::$config['debug']` directly.

### New Behavior
- Uses null coalescing operator to safely access debug configuration
- Defaults to SMTP::DEBUG_OFF if debug is not set
- Makes debug configuration optional

The change makes the Mailer more robust by preventing PHP warnings when the debug configuration isn't set explicitly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

This is a backward-compatible bug fix that maintains the same functionality while making the code more resilient.

## Related Issue

No existing issue, but this fixes a common error when using Leaf Mail without explicit debug configuration. The error manifests as:

Mail Error: Undefined array key "debug"

This fix makes the mail configuration more forgiving by providing sensible defaults.